### PR TITLE
Feature/upload sound

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "firebase": "^11.8.1"
+      },
+      "devDependencies": {
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@firebase/ai": {
@@ -969,6 +972,20 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "description": "",
   "dependencies": {
     "firebase": "^11.8.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,19 @@
                 <a href="#" class="nav-link">首頁</a>
                 <a href="#" class="nav-link">音效列表</a>
                 <a href="#" class="nav-link">關於我們</a>
+                <!-- 使用者選單按鈕（預設隱藏，登入後顯示） -->
+                <div id="user-menu-container" class="user-menu-container" style="display:none;">
+                    <button id="user-menu-btn" class="nav-link user-btn">
+                        <span id="user-name"></span>
+                        <img id="user-avatar" src="" alt="avatar" class="user-avatar" style="display:none;">
+                        <span class="dropdown-arrow">▼</span>
+                    </button>
+                    <div id="user-dropdown" class="user-dropdown" style="display:none;">
+                        <button id="upload-audio-btn" class="dropdown-item">⬆️ 上傳音檔</button>
+                        <button id="logout-btn" class="dropdown-item">登出</button>
+                    </div>
+                </div>
+                <!-- 登入按鈕（預設顯示，登入後隱藏） -->
                 <button id="discord-login" class="nav-link login-btn" onclick="loginWithDiscord()">
                     <img src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0a6a49cf127bf92de1e2_icon_clyde_white_RGB.png" alt="Discord" class="discord-icon">
                     使用 Discord 登入

--- a/public/index.html
+++ b/public/index.html
@@ -108,5 +108,7 @@
     <script src="/js/auth.js" type="module"></script>
     <script src="/js/dclogin.js" type="module"></script>
     <script src="/js/script.js" type="module"></script>
+    <script src="/js/uploadsounds.js" type="module"></script>
+    <script src="/js/soundBtns.js" type="module"></script>
 </body>
 </html> 

--- a/public/js/dclogin.js
+++ b/public/js/dclogin.js
@@ -8,27 +8,52 @@ const app = initializeApp(firebaseConfig);
 // Set up auth state listener
 firebase.auth().onAuthStateChanged((user) => {
     const loginBtn = document.getElementById("discord-login");
-    if (loginBtn) {
-        if (user) {
-            // 用戶已登入
-            loginBtn.innerHTML = `
-                <img src="${user.photoURL || 'https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0a6a49cf127bf92de1e2_icon_clyde_white_RGB.png'}" 
-                     alt="Discord" 
-                     class="discord-icon">
-                ${user.displayName || '已登入'}
-            `;
-            loginBtn.onclick = logout;
-            loadUserData(user.uid);
-        } else {
-            // 用戶未登入
-            loginBtn.innerHTML = `
-                <img src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0a6a49cf127bf92de1e2_icon_clyde_white_RGB.png" 
-                     alt="Discord" 
-                     class="discord-icon">
-                使用 Discord 登入
-            `;
-            loginBtn.onclick = loginWithDiscord;
+    const userMenu = document.getElementById("user-menu-container");
+    
+    if (!loginBtn || !userMenu) {
+        console.log('loginBtn:', loginBtn, 'userMenu:', userMenu);
+        let missing = [];
+        if (!loginBtn) missing.push('loginBtn');
+        if (!userMenu) missing.push('userMenu');
+        console.warn(`dclogin.js: 以下元素不存在 [${missing.join(', ')}]，跳過 onAuthStateChanged`);
+        return; // 頁面沒有這些元素就直接跳過
+    }
+    
+    if (user) {
+        // 顯示 user menu
+        loginBtn.style.display = "none";
+        userMenu.style.display = "inline-block";
+        document.getElementById("user-name").textContent = user.displayName || "已登入";
+        if (user.photoURL) {
+            const avatar = document.getElementById("user-avatar");
+            avatar.src = user.photoURL;
+            avatar.style.display = "inline-block";
         }
+        // 綁定登出
+        document.getElementById("logout-btn").onclick = logout;
+        // 綁定上傳
+        document.getElementById("upload-audio-btn").onclick = function() {
+            // TODO: 上傳邏輯
+            alert('上傳功能尚未實作');
+        };
+        // 下拉選單切換
+        const userMenuBtn = document.getElementById('user-menu-btn');
+        const userDropdown = document.getElementById('user-dropdown');
+        if (userMenuBtn && userDropdown) {
+            userMenuBtn.onclick = function(e) {
+                e.stopPropagation();
+                userDropdown.style.display = userDropdown.style.display === 'block' ? 'none' : 'block';
+            };
+            document.addEventListener('click', function() {
+                userDropdown.style.display = 'none';
+            });
+        }
+        loadUserData(user.uid);
+    } else {
+        // 顯示登入按鈕
+        loginBtn.style.display = "";
+        userMenu.style.display = "none";
+        loginBtn.onclick = loginWithDiscord;
     }
 });
 

--- a/public/js/dclogin.js
+++ b/public/js/dclogin.js
@@ -31,11 +31,6 @@ firebase.auth().onAuthStateChanged((user) => {
         }
         // 綁定登出
         document.getElementById("logout-btn").onclick = logout;
-        // 綁定上傳
-        document.getElementById("upload-audio-btn").onclick = function() {
-            // TODO: 上傳邏輯
-            alert('上傳功能尚未實作');
-        };
         // 下拉選單切換
         const userMenuBtn = document.getElementById('user-menu-btn');
         const userDropdown = document.getElementById('user-dropdown');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,64 +1,11 @@
-class ButtonsService {
-    async getButtons() {
-        try {
-            const response = await fetch('data.json');
-            const data = await response.json();
-            return data.soundButtons;
-        } catch (error) {
-            console.error('載入按鈕資料失敗:', error);
-            return [];
-        }
-    }
-}
-
 // 移動端選單切換
-document.addEventListener('DOMContentLoaded', async () => {
-    //載入並取得data.json的資料
-    const buttonsService = new ButtonsService();
-    const soundButtons = await buttonsService.getButtons();
-    
+document.addEventListener('DOMContentLoaded', () => {
     const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
     const navLinks = document.querySelector('.nav-links');
 
-    mobileMenuBtn.addEventListener('click', () => {
-        navLinks.classList.toggle('active');
-    });
-
-    // 創建音效按鈕
-    const buttonGrid = document.querySelector('.button-grid');
-    
-    soundButtons.forEach(button => {
-        // 創建按鈕元素
-        const buttonElement = document.createElement('button');
-        buttonElement.className = 'sound-button';
-        // 創建 span 元素
-        const spanElement = document.createElement('span');
-        spanElement.className = 'button-label';
-        spanElement.textContent = button.label;  // 使用 textContent 而不是 innerHTML
-        // 將 span 加入到 button 中
-        buttonElement.appendChild(spanElement);
-
-
-        // 創建音效物件
-        const audio = new Audio(button.soundUrl);
-        
-        buttonElement.addEventListener('click', () => {
-            // 停止其他正在播放的音效 (其實只移除視覺效果，但沒關係，我喜歡)
-            document.querySelectorAll('.sound-button').forEach(btn => {
-                btn.classList.remove('playing');
-            });
-            
-            // 播放音效
-            audio.currentTime = 0;
-            audio.play();
-            buttonElement.classList.add('playing');
-            
-            // 音效播放結束後移除播放狀態
-            audio.onended = () => {
-                buttonElement.classList.remove('playing');
-            };
+    if (mobileMenuBtn && navLinks) { // Added null check for robustness
+        mobileMenuBtn.addEventListener('click', () => {
+            navLinks.classList.toggle('active');
         });
-        
-        buttonGrid.appendChild(buttonElement);
-    });
+    }
 });

--- a/public/js/soundBtns.js
+++ b/public/js/soundBtns.js
@@ -1,0 +1,97 @@
+// 從 Firestore 讀取並產生音效按鈕
+// 需先在 index.html 載入 firebase 相關 SDK (app, auth, firestore)
+
+document.addEventListener('DOMContentLoaded', () => {
+    const buttonGrid = document.querySelector('.button-grid');
+
+    if (!buttonGrid) {
+        console.warn('soundBtns.js: .button-grid element not found. Cannot create sound buttons.');
+        return;
+    }
+
+    // 確保 Firebase SDK 已載入且 Firestore 可用
+    if (typeof firebase === 'undefined' || typeof firebase.firestore === 'undefined') {
+        console.error('soundBtns.js: Firebase Firestore SDK is not loaded. Cannot create sound buttons.');
+        // 你可能想在這裡提示使用者，或嘗試延遲執行/重試
+        return;
+    }
+
+    const db = firebase.firestore();
+
+    db.collection('sounds').orderBy('createdAt', 'desc').onSnapshot(snapshot => {
+        buttonGrid.innerHTML = ''; // 清空舊按鈕，避免重複
+
+        if (snapshot.empty) {
+            // console.log("No sounds found in Firestore.");
+            // 你可以在這裡顯示一個 "尚無音效" 的訊息
+            // e.g., buttonGrid.innerHTML = '<p>尚無音效，快上傳你的第一個音效吧！</p>';
+            return;
+        }
+
+        snapshot.forEach(doc => {
+            const sound = doc.data();
+            if (!sound.name || !sound.url) {
+                console.warn('Skipping sound due to missing name or URL:', { id: doc.id, ...sound });
+                return; // 跳過缺少必要資料的音效
+            }
+
+            // 創建按鈕元素
+            const buttonElement = document.createElement('button');
+            buttonElement.className = 'sound-button';
+            
+            // 創建 span 元素放置標籤
+            const spanElement = document.createElement('span');
+            spanElement.className = 'button-label';
+            spanElement.textContent = sound.name; // 使用 Firestore 中的 name
+            buttonElement.appendChild(spanElement);
+
+            // 創建音效物件
+            const audio = new Audio(sound.url); // 使用 Firestore 中的 url
+            
+            // 將 audio 物件附加到按鈕元素上，方便之後控制
+            buttonElement.audioObject = audio;
+
+            buttonElement.addEventListener('click', () => {
+                // 停止其他正在播放的音效 (視覺效果 + 實際暫停)
+                document.querySelectorAll('.sound-button.playing').forEach(btn => {
+                    if (btn !== buttonElement) {
+                        btn.classList.remove('playing');
+                        if (btn.audioObject && typeof btn.audioObject.pause === 'function') {
+                            btn.audioObject.pause();
+                            // 如果希望其他音效也從頭開始，可以加上：
+                            // btn.audioObject.currentTime = 0; 
+                        }
+                    }
+                });
+                
+                // 播放或暫停目前音效
+                if (audio.paused) {
+                    audio.currentTime = 0; // 確保從頭播放
+                    audio.play()
+                        .then(() => {
+                            buttonElement.classList.add('playing');
+                        })
+                        .catch(error => {
+                            console.error("Error playing audio:", {error, soundName: sound.name, soundUrl: sound.url});
+                            // 可以考慮移除 playing class，如果播放失敗
+                            buttonElement.classList.remove('playing');
+                        });
+                } else {
+                    audio.pause();
+                    buttonElement.classList.remove('playing');
+                }
+            });
+            
+            // 音效播放結束後移除播放狀態
+            audio.onended = () => {
+                buttonElement.classList.remove('playing');
+            };
+
+            buttonGrid.appendChild(buttonElement);
+        });
+    }, error => {
+        console.error("Error fetching sounds from Firestore: ", error);
+        // 你可以在這裡顯示一個錯誤訊息給使用者
+        // e.g., buttonGrid.innerHTML = '<p>讀取音效失敗，請稍後再試。</p>';
+    });
+});

--- a/public/js/uploadsounds.js
+++ b/public/js/uploadsounds.js
@@ -1,0 +1,143 @@
+// 音效上傳功能（使用自訂 modal 表單）
+// 需先在 index.html 載入 firebase 相關 SDK
+
+// 建立 modal HTML
+function createUploadModal() {
+  let modal = document.getElementById('upload-audio-modal');
+  if (modal) return modal; // 已存在就不重複建立
+
+  // 如果 modal 不存在，則動態建立一個 div 元素作為 modal 的容器
+  modal = document.createElement('div');
+  modal.id = 'upload-audio-modal';  // 設定 modal 的 ID，方便之後選取
+
+  // 使用 template literal (反引號 `` ` ``) 來定義 modal 的內部 HTML 結構
+  modal.innerHTML = `
+  <div class="modal-backdrop" style="position:fixed;top:0;left:0;width:100vw;height:100vh;background:rgba(0,0,0,0.4);z-index:9998;"></div>
+  <div class="modal-content" style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:32px 24px;border-radius:10px;box-shadow:0 4px 24px rgba(0,0,0,0.18);z-index:9999;min-width:300px;max-width:90vw;">
+    <h2 style="margin-bottom:18px;">上傳音效</h2>
+    <div style="font-size:0.95em;color:#555;margin-bottom:12px;">
+      <b>說明：</b><br>
+      「日期」請填寫音效原影片的發布日期。<br>
+      「時間」請填寫音效在影片中的時間戳記（格式：小時:分鐘，例如 01:22）。
+    </div>
+    <form id="upload-audio-form">
+      <label>名稱：<input type="text" id="audio-name" required maxlength="30" style="width:100%;margin-bottom:10px;"></label><br>
+      <label>日期（原影片發布日期）：<input type="date" id="audio-date" required style="width:100%;margin-bottom:10px;"></label><br>
+      <label>時間（音效在影片中的時間戳記）：<input type="text" id="audio-time" required pattern="^\\d{2}:\\d{2}$" placeholder="hh:mm" style="width:100%;margin-bottom:10px;"></label><br>
+      <label>選擇 mp3 檔案：<input type="file" id="audio-file" accept=".mp3,audio/mp3,audio/mpeg" required style="margin-bottom:10px;"></label><br>
+      <div id="audio-upload-error" style="color:#d00;margin-bottom:10px;"></div>
+      <button type="submit" style="background:#5865F2;color:#fff;padding:8px 24px;border:none;border-radius:4px;cursor:pointer;">上傳</button>
+      <button type="button" id="audio-upload-cancel" style="margin-left:10px;">取消</button>
+    </form>
+  </div>
+`;
+
+  // 將建立好的 modal 加入到網頁的 body 中
+  document.body.appendChild(modal);
+  return modal;  // 回傳建立好的 modal 元素
+}
+
+function showUploadModal() {
+  const modal = createUploadModal();  // 取得或建立 modal
+  modal.style.display = 'block';  // 將 modal 設為可見
+  
+  // 幫背景和取消按鈕加上點擊事件，點擊時關閉 modal
+  modal.querySelector('.modal-backdrop').onclick = closeUploadModal;
+  modal.querySelector('#audio-upload-cancel').onclick = closeUploadModal;
+}
+
+function closeUploadModal() {
+  const modal = document.getElementById('upload-audio-modal');
+  if (modal) modal.style.display = 'none';  // 將 modal 設為隱藏
+}
+
+const uploadBtn = document.getElementById('upload-audio-btn');
+if (uploadBtn) {
+  uploadBtn.addEventListener('click', showUploadModal);
+}
+
+// 表單提交處理
+function handleUploadFormSubmit(e) {
+  e.preventDefault();  // 防止表單提交導致頁面刷新
+
+   // 從表單中取得使用者輸入的值
+  const name = document.getElementById('audio-name').value.trim();
+  const date = document.getElementById('audio-date').value;
+  const time = document.getElementById('audio-time').value;
+  const fileInput = document.getElementById('audio-file');
+  const file = fileInput.files[0];
+  const errorDiv = document.getElementById('audio-upload-error');
+  errorDiv.textContent = '';  // 清空先前的錯誤訊息
+
+  // ---- 前端驗證 ----
+  if (!name || !date || !time || !file) {
+    errorDiv.textContent = '請完整填寫所有欄位並選擇檔案';
+    return;
+  }
+  // 名稱不允許底線，避免與檔名組合衝突
+  if (name.includes('_')) {
+    errorDiv.textContent = '名稱不能包含底線 _';
+    return;
+  }
+  // 日期格式 YYYY-MM-DD 轉 YYYYMMDD
+  const dateStr = date.replace(/-/g, '');
+  if (!/^\d{8}$/.test(dateStr)) {
+    errorDiv.textContent = '日期格式錯誤';
+    return;
+  }
+  // 時間格式 hh:mm 轉 hhmm
+  const timeStr = time.replace(':', '');
+  if (!/^\d{2}:\d{2}$/.test(time)) {
+    errorDiv.textContent = '時間格式錯誤，請輸入 hh:mm（如 01:22）';
+    return;
+  }
+  // 檢查副檔名與 MIME type
+  const isMp3 = file.type === 'audio/mp3' || file.type === 'audio/mpeg' || file.name.toLowerCase().endsWith('.mp3');
+  if (!isMp3) {
+    errorDiv.textContent = '只允許上傳 mp3 檔案';
+    return;
+  }
+  // ---- 組合檔名 ----
+  const filename = `${name}_${dateStr}_${timeStr}.mp3`;
+
+  // ---- 上傳音效 ----
+  (async () => {
+    try {
+      const user = firebase.auth().currentUser;  // 取得目前登入的使用者
+      if (!user) {
+        errorDiv.textContent = '請先登入';
+        return;
+      }
+      // 建立 Firebase Storage 的參照路徑(根目錄:sounds/)
+      const storageRef = firebase.storage().ref('sounds/' + filename);
+      // 上傳檔案
+      const uploadTask = await storageRef.put(file);
+      // 取得上傳後的檔案下載連結
+      const url = await uploadTask.ref.getDownloadURL();
+      // 寫入 Firestore
+      await firebase.firestore().collection('sounds').add({
+        name: name,
+        date: dateStr,
+        time: timeStr,
+        url: url,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        uploader: user.uid,
+        uploaderName: user.displayName || '' // 如果 user.displayName 沒有值（例如使用者沒有設置名稱），就用空字串 '' 代替，避免出現 undefined
+        // 或從 Firestore users collection 讀 username
+      });
+      closeUploadModal();
+      alert('上傳成功！');
+    } catch (err) {
+      console.error('上傳失敗', err);
+      errorDiv.textContent = '上傳失敗：' + err.message;
+    }
+  })();
+}
+
+// 綁定表單 submit
+// 用事件代理，因為 modal 可能是動態產生
+window.addEventListener('submit', function(e) {
+  if (e.target && e.target.id === 'upload-audio-form') {
+    handleUploadFormSubmit(e);
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -246,3 +246,56 @@ body {
     font-weight: 500;
     margin-top: 8px;
 }
+
+.user-menu-container {
+    position: relative;
+    display: inline-block;
+}
+.user-btn {
+    background: none;
+    border: none;
+    color: #333;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 1rem;
+    padding: 0 8px;
+}
+.user-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+}
+.dropdown-arrow {
+    font-size: 0.8em;
+}
+.user-dropdown {
+    position: absolute;
+    right: 0;
+    top: 110%;
+    background: #fff;
+    color: #333;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    min-width: 140px;
+    width: max-content;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+}
+.dropdown-item {
+    width: 100%;
+    box-sizing: border-box;
+    display: block;
+    text-align: left;
+    background: none;
+    border: none;
+    padding: 12px 20px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background 0.2s;
+}
+.dropdown-item:hover {
+    background: #f0f0f0;
+}

--- a/storage.rules
+++ b/storage.rules
@@ -5,6 +5,11 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+    // 只允許登入用戶讀寫 sounds/ 目錄
+    match /sounds/{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+    // 其他目錄預設禁止
     match /{allPaths=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
day 4 總結 - 上傳音檔功能
01. 建立分支 : git checkout -b feature/upload-sound
02. 更新首頁UI : 新增上傳音檔按鈕

03. 更新 dclogin.js : 登入後，點擊使用者按鈕出現下拉選單 - 包含上傳音檔和登出按鈕 (上傳功能之後會分離出去)
03-01. 問題解決 : `firebase deploy` 順利通過 lint 和部署！
 a. 將 index.ts 和 .eslintrc.js 中的 CRLF 切換成 LF : IDE 軟體右下角可以切換
 b. 安裝最新 firebase-tools
 c. 將 typescript 版本降為 5.1.6
03-02. 問題解決 : dclogin.js 載入時機太早無法顯示使用者選單
 a. " if (!loginBtn || !userMenu) return; " : 不會報錯，onAuthStateChanged 也不會被中斷，也不會影響其他功能
 b. 更詳細報錯 : 加入 console : loginBtn || userMenu 異常時印出 log
03-03. 修改 styles.css : 下拉選單內的選項可點擊區域的寬度一致

04. git 會把 LF 換成 CRLF : 設定 Git 全域行為，強制所有 commit 都用 LF - git config --global core.autocrlf input
05. 新增 uploadsounds.js : 專心處理音效上傳、檔案驗證、Storage/Firestore 寫入
06. 修改 script.js : 移除建立音效按鈕的功能，只保留移動端選單切換的功能

07. 新增 soundBtns.js : 從 Firestore 讀取並產生音效按鈕
07-01. 自動從 Firestore 讀取所有音效資料，並即時產生對應的播放按鈕
07-02. 按鈕名稱來自 Firestore 的 `name` 欄位，點擊可播放/暫停音效，且同時只會有一個音效播放
07-03. 音效資料有變動時，按鈕會自動更新
07-04. 問題解決 : 
 a. sound collections 會在上傳第一筆資料的時候建立，這個功能寫在 uploadsounds.js
 b. 上傳一筆新音效檔案後網頁的音效按鈕會清空，再根據firestore的資料重建，確保一致性，重開網頁音效按鈕不會消失
 c. 按鈕有 css 樣式
 P.S 之後可能需要新增刪除功能，並且該功能只有管理員能使用 (也可能不用)

08. 修改 uploadsounds.js : 建立動態 modal 上傳表單 - 填入名稱、原影片日期、音效擷取時間，並串接上傳流程
08-01. 點擊「上傳音檔」彈出自訂 modal，讓使用者填寫「名稱」、「原影片日期」、「音效擷取時間」並選擇 mp3 檔案
08-02. 前端驗證所有欄位、檔名格式、檔案型態
08-03. 自動組合檔名（名稱_日期_時間.mp3），上傳到 Storage
08-04. Firestore 分開儲存 name、date、time、url 等欄位
08-05. 上傳成功/失敗都有提示，modal 也會自動關閉

09. 上傳失敗 : Firebase Storage: User does not have permission to access 'sounds/阿蕾HAPPY_20250225_0122.mp3'. 
09-01. 問題解決 : 修改 storage rules 
 a. 原本規則 : allow read, write: if false;  //所有人都不能讀也不能寫
 b. 修改規則 : allow read, write: if request.auth != null;  //只允許登入用戶讀寫 sounds/ 目錄

10. 修改 uploadsounds.js : 記錄上傳者的 username 到 firestore

11. 修改 uploadsounds.js : 在 modal 表單加入說明文字
11-01. pattern 驗證與前端驗證都要求 hh:mm，錯誤訊息也同步更新